### PR TITLE
Also allow SoftwareSerial for ESP based devices (ESP8266, ESP32)

### DIFF
--- a/src/BGT24LTR11.cpp
+++ b/src/BGT24LTR11.cpp
@@ -314,7 +314,7 @@ uint16_t BGT24LTR11<T>::getThreshold() {
 #endif
 template class BGT24LTR11<HardwareSerial>;
 
-#ifdef __AVR__
+#if defined(__AVR__) || defined(ESP8266) || defined(ESP32)
     #include <SoftwareSerial.h>
     template class BGT24LTR11<SoftwareSerial>;
 #endif


### PR DESCRIPTION
This PR also enables the library to be used with SoftwareSerial on ESP based devices (where the HardwareSerial is often connected to the USB-to-serial chip for serial monitor and programming).

While the default ESP SoftwareSerial implementation is said to not be very reliant/stable, there is https://github.com/plerup/espsoftwareserial which should work.