### PR TITLE
remove checks that always evaluate to false due to range of uint16_t

### DIFF
--- a/src/BGT24LTR11.cpp
+++ b/src/BGT24LTR11.cpp
@@ -102,7 +102,7 @@ uint8_t BGT24LTR11<T>::setSpeedScope(uint16_t maxspeed, uint16_t minspeed) {
     uint16_t data[8] = {0};
     uint16_t len = 0;
     unsigned char commandC3[11] = {0x55, 0x2A, 0xC3, 0x00, 0x06, 0x02, 0x09, 0x01, 0x03, 0x01, 0x57};
-    if ((maxspeed > 65535) || (minspeed < 0) || (maxspeed < minspeed)) {
+    if (maxspeed < minspeed) {
         return 0;
     }
     commandC3[5] = maxspeed / 256;
@@ -172,7 +172,7 @@ uint8_t BGT24LTR11<T>::getSpeedScope(uint16_t* maxspeed, uint16_t* minspeed) {
 ****************************************************************/
 template <class T>
 uint8_t BGT24LTR11<T>::setMode(uint16_t mode) {
-    if (mode > 1 || mode < 0) {
+    if (mode > 1) {
         return 0;
     }
     unsigned char commandC5[8] = {0x55, 0x2A, 0xC5, 0x00, 0x03, 0x00, 0x01, 0x47};


### PR DESCRIPTION
otherwise -Wtype-limits (e.g. Arduino IDE) generates warnings like:

```
warning: comparison is always false due to limited range of data type [-Wtype-limits]
```

uint16_t range is from 0 to 65536 so when passing any other value, the type conversion should happen beforehand and the check is not needed again.