### PR TITLE
remove unneeded delay

### DIFF
--- a/src/BGT24LTR11.cpp
+++ b/src/BGT24LTR11.cpp
@@ -55,7 +55,6 @@ uint16_t BGT24LTR11<T>::getTargetState() {
                 }
             }
         }
-        delay(20);
         /* code */
     }
     return 0;


### PR DESCRIPTION
since its also not present at getSpeed (which is the same command)

also tested with real hardware