### PR TITLE
implement checksum as described in radar communication protocol v1.1

### DIFF
--- a/src/BGT24LTR11.h
+++ b/src/BGT24LTR11.h
@@ -46,6 +46,9 @@ class BGT24LTR11 {
     uint8_t getMode();
     uint8_t setThreshold(uint16_t whreshold);
     uint16_t getThreshold();
+    uint16_t calculateChecksum(uint16_t *data, uint16_t data_length);
+    uint16_t messageChecksum(uint16_t high_order, uint16_t low_order);
+
 };
 
 #endif


### PR DESCRIPTION
and use it in the commands to verify delivered checksum against calculated one.

this gets rid of many unplausable values where some bytes were lost in transmission and therefor the data array is at an offset and makes no sense. hence, before this commit, the data was parsed and evaluated as result.

this is the first step, to mitigate data consistency issues, a better approach would be to do the parsing independently from the serial reading.