### PR TITLE
implement single query getInfo call

### DIFF
--- a/src/BGT24LTR11.h
+++ b/src/BGT24LTR11.h
@@ -45,7 +45,7 @@ class BGT24LTR11 {
     uint8_t getSpeedScope(uint16_t* maxspeed, uint16_t* minspeed);
     uint8_t setMode(uint16_t mode);
     uint8_t getMode();
-    uint8_t setThreshold(uint16_t whreshold);
+    uint8_t setThreshold(uint16_t threshold);
     uint16_t getThreshold();
     uint16_t calculateChecksum(uint16_t *data, uint16_t data_length);
     uint16_t messageChecksum(uint16_t high_order, uint16_t low_order);

--- a/src/BGT24LTR11.h
+++ b/src/BGT24LTR11.h
@@ -37,6 +37,7 @@ class BGT24LTR11 {
     /* data */
   public:
     void init(T& serialPort);
+    uint8_t getInfo(uint16_t* target_tate, uint16_t* speed);
     uint16_t getSpeed();
     uint16_t getTargetState();
     uint8_t getIQADC(uint16_t I_d[], uint16_t Q_d[], uint16_t* len);


### PR DESCRIPTION
so that target detection and speed can be evaluated with one serial send (since the answer provides both already).

This reduces the load on the UART port and ensures that the received data is from the same sampling frame. Otherwise it could be that between `getTargetState()` and `getSpeed()` the module updated its values.

Example usage:
```
  uint16_t state = 0;
  uint16_t speed = 0;

  if (BGT.getInfo(&state, &speed)) {
    if (state == 2) {
      digitalWrite(5, HIGH);
      ShowSerial.print("target approach");
    } else if (state == 1) {
      digitalWrite(5, LOW);
      ShowSerial.print("target leave   ");
    } else {
      ShowSerial.println("no target");
      return;
    }

    ShowSerial.print(" - target speed: ");
    ShowSerial.println(speed);
  }
```

Tested on a Sparkfun ESP32 Thing with the real hardware module. Arduino IDE with espressif 2.0.6.

Old functions are left for backwards compatibility.